### PR TITLE
Workaround for fixing build on FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2"
 log = "0.3"
 multimap = "0.3"
 net2 = "0.2"
-nix = "0.8"
+nix = { git = "https://github.com/nix-rust/nix" }
 rand = "0.3"
 tokio-core = "0.1.1"
 


### PR DESCRIPTION
Change nix path/version to current -dev, so that it builds fine on FreeBSD